### PR TITLE
add conventional commit message validation

### DIFF
--- a/.github/workflows/check-commit-convention.yaml
+++ b/.github/workflows/check-commit-convention.yaml
@@ -1,0 +1,28 @@
+name: Check Commit Convention
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  commitlint:
+    name: Check Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install commitlint
+        run: |
+          npm install --save-dev @commitlint/cli @commitlint/config-conventional
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+
+      - name: Check commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --to ${{ github.event.pull_request.head.sha || 'HEAD' }} --verbose


### PR DESCRIPTION
# Add Conventional Commit Message Validation

## Description
This PR adds a GitHub Actions workflow to validate that commit messages follow the conventional commit format.

## Changes
- Add `.github/workflows/check-commit-convention.yaml` workflow that runs commitlint
- Validates commits follow conventional format (feat:, fix:, chore:, etc.)
- Runs on all PRs and direct pushes to master branch

## Benefits
- Enforces consistent commit message format across the project
- Improves readability of commit history
- Makes automated changelog generation possible in the future